### PR TITLE
Write script on Windows

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,9 @@
 
  - 完善Windows 10同步、Microsoft Store、Microsoft Account
  - 增加批处理，方便导入
+## 已增加批处理（暂时仅windows可用）
+ - 使用python编写了导入脚本，源代码在项目[addHosts.py](https://github.com/MattMaBX/Microsoft-Hosts/blob/master/addHosts.py)文件中
+ - 使用时需用管理员权限打开[addHosts.exe](https://github.com/MattMaBX/Microsoft-Hosts/blob/master/addHosts.exe)(因为hosts文件的改动必须使用管理员权限)
   
 # 注意事项
 

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
 # 计划列表
 
  - 完善Windows 10同步、Microsoft Store、Microsoft Account
- - 增加批处理，方便导入
+ - 增加批处理，方便导入(已实现)
 ## 已增加批处理（暂时仅windows可用）
  - 使用python编写了导入脚本，源代码在项目[addHosts.py](https://github.com/MattMaBX/Microsoft-Hosts/blob/master/addHosts.py)文件中
  - 使用时需用管理员权限打开[addHosts.exe](https://github.com/MattMaBX/Microsoft-Hosts/blob/master/addHosts.exe)(因为hosts文件的改动必须使用管理员权限)

--- a/addHosts.py
+++ b/addHosts.py
@@ -1,0 +1,33 @@
+#coding:utf-8
+import os
+#备份原hosts
+Local_hosts = open("C:\\Windows\\System32\\drivers\\etc\\hosts",mode='w+',encoding='utf-8')
+Local_backup = open("C:\\Windows\\System32\\drivers\\etc\\hosts.bak",mode='w+',encoding='utf-8')
+for line in Local_hosts.readlines():
+    Local_backup.write(line)
+Local_hosts = open("C:\\Windows\\System32\\drivers\\etc\\hosts",mode='a+',encoding='utf-8')
+#选择想要写入的文件
+print(\
+"***********************************************************************\n\
+****** \t\t\t添加哪一个hosts文件？\t\t\t*******\n\
+***********************************************************************\n")
+while True:
+    Option = input("1.hosts(全部微软系hosts) 2.hosts-testing(测试版本) 3.onenote_hosts(仅onenote)\n")
+    if Option == '1' or Option == 'hosts':
+        New_hosts = open('hosts',encoding='utf-8')
+        break
+    elif Option == '2' or Option == 'hosts-testing':
+        New_hosts = open('hosts-testing',encoding='utf-8')
+        break
+    elif Option == '3' or Option == 'onenote_hosts':
+        New_hosts = open('onenote_hosts',encoding='utf-8')
+        break
+    else:
+        print("输入有误 请输入序号或hosts文件名\n")
+#写入文件
+Local_hosts.write('\n\n')
+for line in New_hosts.readlines():
+    Local_hosts.write(line)
+New_hosts.close()
+Local_hosts.close()
+input("***** \t\t\t写入成功!按任意键退出\t\t\t *****")

--- a/addHosts.py
+++ b/addHosts.py
@@ -1,11 +1,12 @@
 #coding:utf-8
-import os
 #备份原hosts
-Local_hosts = open("C:\\Windows\\System32\\drivers\\etc\\hosts",mode='w+',encoding='utf-8')
+Local_hosts = open("C:\\Windows\\System32\\drivers\\etc\\hosts",mode='a+',encoding='utf-8')
+Local_hosts.seek(0,0)
 Local_backup = open("C:\\Windows\\System32\\drivers\\etc\\hosts.bak",mode='w+',encoding='utf-8')
 for line in Local_hosts.readlines():
     Local_backup.write(line)
-Local_hosts = open("C:\\Windows\\System32\\drivers\\etc\\hosts",mode='a+',encoding='utf-8')
+Local_hosts.seek(0,2)
+Local_backup.close()
 #选择想要写入的文件
 print(\
 "***********************************************************************\n\

--- a/addHosts.py
+++ b/addHosts.py
@@ -7,7 +7,7 @@ for line in Local_hosts.readlines():
     Local_backup.write(line)
 Local_hosts.seek(0,2)
 Local_backup.close()
-#选择想要写入的文件
+#选择要写入的文件
 print(\
 "***********************************************************************\n\
 ****** \t\t\t添加哪一个hosts文件？\t\t\t*******\n\


### PR DESCRIPTION
编写了在Windows上可用的脚本，来进行hosts文件的添加
运行时会自动在系统的hosts目录下创建原hosts的备份hosts.bak
脚本代码在addHosts.py中，使用pyinstaller打包为exe
运行方式：1.无需配置环境，直接以管理员身份运行addHosts.exe  2.（需要python环境）以管理员身份启动Powershell或cmd，在项目路径下运行"python addHosts.py"命令即可